### PR TITLE
feat: track unique web asset over which we are creating highlights

### DIFF
--- a/src/Highlight/container.ts
+++ b/src/Highlight/container.ts
@@ -13,9 +13,7 @@ export class HighlightContainerAppModel implements IHighlightCollectionAppModel 
 }
 
 export class HighlightContainerRuntimeFactory extends NostrContainerRuntimeFactory<HighlightContainerAppModel> {
-	public constructor() /** Unique identifier of the web resource being highlighted // private readonly assetHash: string,
-	 * Possibly create this by hashing the URI of the web asset being highlighted
-	 */ {
+	public constructor() {
 		super(new Map([HighlightCollectionInstantiationFactory.registryEntry]));
 	}
 

--- a/src/Highlight/interfaces.ts
+++ b/src/Highlight/interfaces.ts
@@ -14,6 +14,7 @@ export interface IHighlight {
 }
 
 export interface IHighlightCollection extends EventEmitter {
+	getHighlightBase(): Promise<string>;
 	addHighlight(highlight: IHighlight): Promise<IHighlight>;
 	removeHighlight(hashId: string): Promise<boolean>;
 	getHighlight(hashId: string): Promise<IHighlight | undefined>;

--- a/src/Highlight/model.ts
+++ b/src/Highlight/model.ts
@@ -1,27 +1,37 @@
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IHighlight, IHighlightCollection } from "./interfaces";
 
+const HIGHLIGHT_BASE_ASSET_KEY = "HIGHLIGHT_BASE_ASSET_KEY";
+const HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE = "HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE";
+
 export class Highlight implements IHighlight {
 	protected constructor(public author: string, public text: string, public hashId: string) {}
 
 	static async create(author: string, text: string) {
-		const encoder = new TextEncoder();
-		const hashArray = Array.from(
-			new Uint8Array(
-				await crypto.subtle.digest("SHA-256", encoder.encode(`${author}-${text}`)),
-			),
-		);
-		const hash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-
+		const hash = await sha256Hash(`${author}-${text}`);
 		return new Highlight(author, text, hash);
 	}
 }
 
 export class HighlightCollection extends DataObject implements IHighlightCollection {
-	protected async initializeFirstTime() {}
+	protected async initializeFirstTime() {
+		// Store  a reference to the web resource we are highlightning, as a sha256 hash of the web url
+		// In case we cannot determine the web url at the time of initialization,
+		// we use a hash of HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE as the base asset reference
+		const base = await sha256Hash(document.location.href || HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE);
+		this.root.set(HIGHLIGHT_BASE_ASSET_KEY, base);
+	}
 
 	protected async hasInitialized() {
 		this.root.on("valueChanged", () => this.emit("highlightCollectionChanged"));
+	}
+
+	async getHighlightBase(): Promise<string> {
+		let base =
+			this.root.get(HIGHLIGHT_BASE_ASSET_KEY) ||
+			sha256Hash(HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE);
+
+		return Promise.resolve(base);
 	}
 
 	async addHighlight(highlight: Highlight): Promise<Highlight> {
@@ -58,3 +68,11 @@ export const HighlightCollectionInstantiationFactory = new DataObjectFactory(
 	[],
 	{},
 );
+
+const sha256Hash = async (message: string): Promise<string> => {
+	const encoder = new TextEncoder();
+	const hashArray = Array.from(
+		new Uint8Array(await crypto.subtle.digest("SHA-256", encoder.encode(message))),
+	);
+	return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+};

--- a/src/Highlight/view.ts
+++ b/src/Highlight/view.ts
@@ -1,7 +1,19 @@
 import { IHighlight, IHighlightCollection } from "./interfaces";
 import { Highlight } from "./model";
 
-export const renderHighlightCollection = (collection: IHighlightCollection, div: HTMLElement, author: string) => {
+export const renderHighlightCollection = (
+	collection: IHighlightCollection,
+	div: HTMLElement,
+	author: string,
+) => {
+	const titleDiv = document.createElement("div");
+	const renderTitle = () => {
+		collection.getHighlightBase().then((base) => {
+			titleDiv.textContent = `Highlight Collection for ${base}`;
+		});
+	};
+	renderTitle();
+
 	const highlightsDiv = document.createElement("div");
 
 	// Pre-render all the highlights
@@ -22,13 +34,12 @@ export const renderHighlightCollection = (collection: IHighlightCollection, div:
 	const inpt = document.createElement("input");
 	inpt.placeholder = "Highlight Text";
 
-	
 	const btn = document.createElement("button");
 	btn.textContent = "Create";
 	btn.addEventListener("click", async () => {
 		const text = inpt.value;
 
-		const highlight = await Highlight.create(author, text);	
+		const highlight = await Highlight.create(author, text);
 		await collection.addHighlight(highlight);
 
 		inpt.value = "";
@@ -37,7 +48,7 @@ export const renderHighlightCollection = (collection: IHighlightCollection, div:
 	addHighlightDiv.append(inpt, btn);
 
 	// Inject the pre-rendered highlights as a list into the DOM
-	div.append(highlightsDiv, addHighlightDiv);
+	div.append(titleDiv, highlightsDiv, addHighlightDiv);
 };
 
 const renderHighlight = (highlight: IHighlight, div: HTMLDivElement) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,14 +15,12 @@ const loadCollabHighlighter = async (pane: HTMLElement, author: string) => {
 	const tokenProvider = new InsecureTinyliciousTokenProvider();
 
 	// Create a new Fluid loader, load the highlight collection
-	const loader = new NostrCollabLoader<IHighlightCollectionAppModel>(
-		{
-			urlResolver: new InsecureTinyliciousUrlResolver(),
-			documentServiceFactory: new RouterliciousDocumentServiceFactory(tokenProvider),
-			codeLoader: new StaticCodeLoader(new HighlightContainerRuntimeFactory()),
-			generateCreateNewRequest: createTinyliciousCreateNewRequest,
-		}
-	);
+	const loader = new NostrCollabLoader<IHighlightCollectionAppModel>({
+		urlResolver: new InsecureTinyliciousUrlResolver(),
+		documentServiceFactory: new RouterliciousDocumentServiceFactory(tokenProvider),
+		codeLoader: new StaticCodeLoader(new HighlightContainerRuntimeFactory()),
+		generateCreateNewRequest: createTinyliciousCreateNewRequest,
+	});
 
 	let id: string;
 	let highlightsCollection: IHighlightCollectionAppModel;
@@ -41,13 +39,12 @@ const loadCollabHighlighter = async (pane: HTMLElement, author: string) => {
 	document.title = id;
 
 	renderHighlightCollection(highlightsCollection.highlightCollection, pane, author);
-}
-
+};
 
 async function start() {
 	// Load Collab highlighter on the LEFT pane
 	const left = document.getElementById("left-hltr");
-	left && await loadCollabHighlighter(left, "left");
+	left && (await loadCollabHighlighter(left, "left"));
 
 	// Load Collab highlighter on the RIGHT pane
 	const right = document.getElementById("right-hltr");


### PR DESCRIPTION
Store  a reference to the web resource we are highlightning, as a sha256 hash of the web url. This hash is created once and stored in a collaborative data object for all highlighting clients to access
```ts
export class HighlightCollection extends DataObject implements IHighlightCollection {
	protected async initializeFirstTime() {
		// Store  a reference to the web resource we are highlightning, as a sha256 hash of the web url
		// In case we cannot determine the web url at the time of initialization,
		// we use a hash of HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE as the base asset reference
		const base = await sha256Hash(document.location.href || HIGHLIGHT_BASE_ASSET_DEFAULT_VALUE);
		this.root.set(HIGHLIGHT_BASE_ASSET_KEY, base);
	}
	
	...
}
```
A highlighter client can retrieve this hash from an api on `HighlightCollection`. Example,
```ts
const renderTitle = () => {
       collection.getHighlightBase().then((base) => {
		titleDiv.textContent = `Highlight Collection for ${base}`;
	});
};
```

![image](https://user-images.githubusercontent.com/11217077/224317325-aba07676-5866-477a-b485-15a745766004.png)

