### PR TITLE
feat: use placeholder @nostrdocs/tinycollab relay server for collab

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"build:dev": "webpack --env clean",
 		"start": "start-server-and-test start:server 8080 start:client",
 		"start:client": "webpack serve",
-		"start:server": "npx tinylicious@latest",
+		"start:server": "npx @nostrdocs/tinycollab@latest",
 		"prettier": "prettier --check . --ignore-path ./.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ./.prettierignore",
 		"test": "start-server-and-test start:server 7070 jest"


### PR DESCRIPTION
This change migrates the highlighter dev experience from Fluidframework collaboration test server named **Tinylicious [code](https://github.com/microsoft/FluidFramework/tree/main/server/tinylicious),  [npm](https://www.npmjs.com/package/tinylicious) to a clone of the same named **@nostrdocs/tinycollab** [code](https://github.com/nostrdocs/tinycollab), [npm](https://www.npmjs.com/package/@nostrdocs/tinycollab)
With this shift, we can now build **@nostrdocs/tinycollab**  into a Nostr relay usable for testing collab experiences over Nostr

![image](https://user-images.githubusercontent.com/11217077/224551438-0978085e-c1ac-4ace-ad01-af3077d6cd65.png)

