### PR TITLE
Nostr collab sketch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/tinylicious-client": "^1.3.0",
+				"@fluidframework/routerlicious-driver": "^1.3.6",
 				"css-loader": "^6.0.0",
 				"fluid-framework": "^1.3.0",
 				"react": "^18.0.0",
@@ -843,9 +843,9 @@
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.5.tgz",
-			"integrity": "sha512-k510EGzIKqJ91PiQVpsKTtOktyTqcK8gFQ/g8GWbT8wdjdSToNCIDuTz+cZARMekafi6o1VgzCVgieiwvj/yuw=="
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.6.tgz",
+			"integrity": "sha512-6ccflpLJvlPhZ58MiMUUC5XvWF1s5yTmP3dXHsJf514IzuAvS5PCGLdZWUjWCgxA2fPvZKzA4VfWpwyFt1H0LA=="
 		},
 		"node_modules/@fluidframework/datastore": {
 			"version": "1.3.5",
@@ -892,41 +892,41 @@
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.5.tgz",
-			"integrity": "sha512-EIF9oQNRosuw3c/pRpD9H8/e9ckU8VT7m2hxQrpSZzV4YM5yMuojnZ/PZ4efkRCj0FzXkJQrjnE0oHq8iaWp9Q==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.6.tgz",
+			"integrity": "sha512-Ini7PyyIP+out9+5eAqq+QYWfxSGprVtxTrtipmoKCjI6XTmgfmSwrs9VPrgdIl6lI52RjEFWQtC/J3vmjAesg==",
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.2",
-				"@fluidframework/driver-definitions": "^1.3.5",
-				"@fluidframework/driver-utils": "^1.3.5",
+				"@fluidframework/driver-definitions": "^1.3.6",
+				"@fluidframework/driver-utils": "^1.3.6",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.3.5"
+				"@fluidframework/telemetry-utils": "^1.3.6"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.5.tgz",
-			"integrity": "sha512-A1Wr2d1LvhtgdedUPmmyIcHD8/Q0ceMqXraLd/+yHXiCr2NMD6ffOaef7LV7PWC2IztO0Hpz5raChlRF8G2r0g==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.6.tgz",
+			"integrity": "sha512-5Rvk2NhXxh2bhk8WWnBtcJq/9TgVYhAj4z7DDuqXqJyRUF/XYhyxqOfMuo7IAhTa2oTpp8o7QDwZqsfWKfC9tA==",
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "^1.3.5",
+				"@fluidframework/core-interfaces": "^1.3.6",
 				"@fluidframework/protocol-definitions": "^0.1028.2000"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.5.tgz",
-			"integrity": "sha512-qzh+wmff/7vtz5JAD3VmIvSh9+k6n+GecjZkh5l4Fk0DGK7xNnyllswjPIkJUQdQvvuDvUMhZLaTN4QlQTIFNQ==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.6.tgz",
+			"integrity": "sha512-yDbuR4eMj0Y+kbIwV0XaXd3kh+U1YxmU1Qgcxa2RgD3MEMsDiCBaQrUCPjjxmBT9diUfBijVxjjOc5vUfm/eBA==",
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.2",
-				"@fluidframework/core-interfaces": "^1.3.5",
-				"@fluidframework/driver-definitions": "^1.3.5",
+				"@fluidframework/core-interfaces": "^1.3.6",
+				"@fluidframework/driver-definitions": "^1.3.6",
 				"@fluidframework/gitresources": "^0.1036.5001",
 				"@fluidframework/protocol-base": "^0.1036.5001",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/telemetry-utils": "^1.3.5",
+				"@fluidframework/telemetry-utils": "^1.3.6",
 				"axios": "^0.26.0",
 				"uuid": "^8.3.1"
 			}
@@ -1041,20 +1041,20 @@
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.5.tgz",
-			"integrity": "sha512-nIX/hu+IFXtuby/fmS3FVYEZx28YIDlivifaHXXFfkRWq6pHPVI+gbE6Y5HuWNBIxte0fWRkLtexfuyKElRUUg==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.6.tgz",
+			"integrity": "sha512-b9NXLWI7YH4l2dEkgjDuIF9BNb1ggxkzS8ZtZpr+eBtegRN+E+WSbkR7JCPwrDmA+vPa9z0mXNS88ZeCwnQp3A==",
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.2",
-				"@fluidframework/driver-base": "^1.3.5",
-				"@fluidframework/driver-definitions": "^1.3.5",
-				"@fluidframework/driver-utils": "^1.3.5",
+				"@fluidframework/driver-base": "^1.3.6",
+				"@fluidframework/driver-definitions": "^1.3.6",
+				"@fluidframework/driver-utils": "^1.3.6",
 				"@fluidframework/gitresources": "^0.1036.5001",
 				"@fluidframework/protocol-base": "^0.1036.5001",
 				"@fluidframework/protocol-definitions": "^0.1028.2000",
 				"@fluidframework/server-services-client": "^0.1036.5001",
-				"@fluidframework/telemetry-utils": "^1.3.5",
+				"@fluidframework/telemetry-utils": "^1.3.6",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"querystring": "^0.2.0",
@@ -1191,9 +1191,9 @@
 			"integrity": "sha512-f7UdtHVMWF8AFUeaBru4u0rVXcR4xR7u4Y2VsjuNnHe2tesaqU+MrYuWRN/Q16JJ/BxeBfkNVqCptYnxL3ZeJQ=="
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.5.tgz",
-			"integrity": "sha512-57/S3feBGqzGk7OwnnDi4yBIWD7NrTie/9PxzqvHDJZUN1pgfuqAHvhR+2g8HX7IGjABnLN8FRnyBzCiJqeBcg==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.6.tgz",
+			"integrity": "sha512-9DoLzKwnELWBN2NiCJPgfj2lCER4IiHSgiBMwbLoEZ0qTqGKhWJ1+7m1PupuwGuKX1zbb9HjUNxv2ommokZcqw==",
 			"dependencies": {
 				"@fluidframework/common-definitions": "^0.20.1",
 				"@fluidframework/common-utils": "^0.32.2",
@@ -1203,60 +1203,6 @@
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.3.5.tgz",
-			"integrity": "sha512-7Q5+h0YCsVcHeYI4Pff4yIC3ly7QfF3n87imYy4GRV4f3mfefJ8mj9tiwjwyFuFwwiIiOMizgZt7tKRC/Zyo+A==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/common-utils": "^0.32.2",
-				"@fluidframework/container-definitions": "^1.3.5",
-				"@fluidframework/container-loader": "^1.3.5",
-				"@fluidframework/driver-definitions": "^1.3.5",
-				"@fluidframework/driver-utils": "^1.3.5",
-				"@fluidframework/fluid-static": "^1.3.5",
-				"@fluidframework/map": "^1.3.5",
-				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.3.5",
-				"@fluidframework/runtime-utils": "^1.3.5",
-				"@fluidframework/tinylicious-driver": "^1.3.5",
-				"uuid": "^8.3.1"
-			},
-			"peerDependencies": {
-				"fluid-framework": "^1.0.0"
-			}
-		},
-		"node_modules/@fluidframework/tinylicious-client/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.3.5.tgz",
-			"integrity": "sha512-hJPPjMv9qPHQaAc9EJjnMz5HK36xrkdXgpoJc3sgiej9SMGY6JVLDsAh7woRyztUuJk6zhPPyCvS2ljAw5biqw==",
-			"dependencies": {
-				"@fluidframework/core-interfaces": "^1.3.5",
-				"@fluidframework/driver-definitions": "^1.3.5",
-				"@fluidframework/driver-utils": "^1.3.5",
-				"@fluidframework/protocol-definitions": "^0.1028.2000",
-				"@fluidframework/routerlicious-driver": "^1.3.5",
-				"@fluidframework/server-services-client": "^0.1036.5001",
-				"jsrsasign": "^10.5.25",
-				"uuid": "^8.3.1"
-			}
-		},
-		"node_modules/@fluidframework/tinylicious-driver/node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test": "start-server-and-test start:server 7070 jest"
 	},
 	"dependencies": {
-		"@fluidframework/tinylicious-client": "^1.3.0",
+		"@fluidframework/routerlicious-driver": "^1.3.6",
 		"css-loader": "^6.0.0",
 		"fluid-framework": "^1.3.0",
 		"react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"build:dev": "webpack --env clean",
 		"start": "start-server-and-test start:server 8080 start:client",
 		"start:client": "webpack serve",
-		"start:server": "npx tinylicious@latest",
+		"start:server": "npx @nostrdocs/tinycollab@latest",
 		"prettier": "prettier --check . --ignore-path ./.prettierignore",
 		"prettier:fix": "prettier --write . --ignore-path ./.prettierignore",
 		"test": "start-server-and-test start:server 7070 jest"

--- a/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
+++ b/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
@@ -1,0 +1,50 @@
+import { ScopeType, ITokenClaims } from "@fluidframework/protocol-definitions";
+import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
+import { getRandomName } from "@fluidframework/server-services-client";
+import { KJUR as jsrsasign } from "jsrsasign";
+import { v4 as uuid } from "uuid";
+
+export class NostrRelayTokenProvider implements ITokenProvider {
+	public async fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
+		return {
+			fromCache: true,
+			jwt: this.getSignedToken(tenantId, documentId),
+		};
+	}
+
+	public async fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse> {
+		return {
+			fromCache: true,
+			jwt: this.getSignedToken(tenantId, documentId),
+		};
+	}
+
+	private getSignedToken(
+		tenantId: string,
+		documentId: string | undefined,
+		lifetime: number = 60 * 60,
+		ver: string = "1.0",
+	): string {
+		// Current time in seconds
+		const now = Math.round(new Date().getTime() / 1000);
+		const user = { id: uuid(), name: getRandomName() };
+
+		const claims: ITokenClaims = {
+			documentId: documentId ?? "",
+			scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+			tenantId,
+			user,
+			iat: now,
+			exp: now + lifetime,
+			ver,
+		};
+
+		const utf8Key = { utf8: "12345" };
+		return jsrsasign.jws.JWS.sign(
+			null,
+			JSON.stringify({ alg: "HS256", typ: "JWT" }),
+			claims,
+			utf8Key,
+		);
+	}
+}

--- a/src/Nostrcollab/driver/NostrRelayUrlResolver.ts
+++ b/src/Nostrcollab/driver/NostrRelayUrlResolver.ts
@@ -1,0 +1,92 @@
+import { IRequest } from "@fluidframework/core-interfaces";
+import {
+	DriverHeader,
+	IFluidResolvedUrl,
+	IResolvedUrl,
+	IUrlResolver,
+} from "@fluidframework/driver-definitions";
+
+export const defaultTinyliciousPort = 7070;
+
+/**
+ * Default endpoint URL base. Will be used by the service if the consumer does not specify an endpoint.
+ */
+export const defaultTinyliciousEndpoint = "http://localhost";
+
+/**
+ * NostrRelayUrlResolver knows how to get the URLs to the service (in this case Tinylicious) to use
+ * for a given request.  This particular implementation has a goal to avoid imposing requirements on the app's
+ * URL shape, so it expects the request url to have this format (as opposed to a more traditional URL):
+ * documentId/containerRelativePathing
+ */
+export class NostrRelayUrlResolver implements IUrlResolver {
+	private readonly fluidProtocolEndpoint: string;
+	private readonly tinyliciousEndpoint: string;
+	public constructor(port = defaultTinyliciousPort, endpoint = defaultTinyliciousEndpoint) {
+		this.tinyliciousEndpoint = `${endpoint}:${port}`;
+		this.fluidProtocolEndpoint = this.tinyliciousEndpoint.replace(/(^\w+:|^)\/\//, "fluid://");
+	}
+
+	public async resolve(request: IRequest): Promise<IResolvedUrl> {
+		// determine whether the request is for creating of a new container.
+		// such request has the `createNew` header set to true and doesn't have a container ID.
+		if (request.headers && request.headers[DriverHeader.createNew] === true) {
+			// honor the document ID passed by the application via the create request
+			// otherwise use the reserved keyword to let the driver generate the ID.
+			// TODO: deprecate this capability for tinylicious as the r11s driver will stop using the document ID
+			// in create requests.
+			const newDocumentId = request.url ?? "new";
+			return {
+				endpoints: {
+					deltaStorageUrl: `${this.tinyliciousEndpoint}/deltas/tinylicious/${newDocumentId}`,
+					ordererUrl: this.tinyliciousEndpoint,
+					storageUrl: `${this.tinyliciousEndpoint}/repos/tinylicious`,
+				},
+				// id is a mandatory attribute, but it's ignored by the driver for new container requests.
+				id: request.url,
+				// tokens attribute is redundant as all tokens are generated via ITokenProvider
+				tokens: {},
+				type: "fluid",
+				url: `${this.fluidProtocolEndpoint}/tinylicious/${newDocumentId}`,
+			};
+		}
+		// for an existing container we'll parse the request URL to determine the document ID.
+		const url = request.url.replace(`${this.tinyliciousEndpoint}/`, "");
+		const documentId = url.split("/")[0];
+		const encodedDocId = encodeURIComponent(documentId);
+		const documentRelativePath = url.slice(documentId.length);
+
+		const documentUrl = `${this.fluidProtocolEndpoint}/tinylicious/${encodedDocId}${documentRelativePath}`;
+		const deltaStorageUrl = `${this.tinyliciousEndpoint}/deltas/tinylicious/${encodedDocId}`;
+		const storageUrl = `${this.tinyliciousEndpoint}/repos/tinylicious`;
+
+		const response: IFluidResolvedUrl = {
+			endpoints: {
+				deltaStorageUrl,
+				ordererUrl: this.tinyliciousEndpoint,
+				storageUrl,
+			},
+			id: documentId,
+			tokens: {},
+			type: "fluid",
+			url: documentUrl,
+		};
+		return response;
+	}
+
+	public async getAbsoluteUrl(
+		resolvedUrl: IFluidResolvedUrl,
+		relativeUrl: string,
+	): Promise<string> {
+		const documentId = decodeURIComponent(
+			resolvedUrl.url.replace(`${this.fluidProtocolEndpoint}/tinylicious/`, ""),
+		);
+		/*
+		 * The detached container flow will ultimately call getAbsoluteUrl() with the resolved.url produced by
+		 * resolve().  The container expects getAbsoluteUrl's return value to be a URL that can then be roundtripped
+		 * back through resolve() again, and get the same result again.  So we'll return a "URL" with the same format
+		 * described above.
+		 */
+		return `${documentId}/${relativeUrl}`;
+	}
+}

--- a/src/Nostrcollab/driver/index.ts
+++ b/src/Nostrcollab/driver/index.ts
@@ -1,0 +1,2 @@
+export * from "./NostrRelayUrlResolver";
+export * from "./utils";

--- a/src/Nostrcollab/driver/index.ts
+++ b/src/Nostrcollab/driver/index.ts
@@ -1,2 +1,3 @@
 export * from "./NostrRelayUrlResolver";
+export * from "./NostrRelayTokenProvider";
 export * from "./utils";

--- a/src/Nostrcollab/driver/utils.ts
+++ b/src/Nostrcollab/driver/utils.ts
@@ -1,0 +1,9 @@
+import { IRequest } from "@fluidframework/core-interfaces";
+import { DriverHeader } from "@fluidframework/driver-definitions";
+
+export const createNostrCreateNewRequest = (documentId?: string): IRequest => ({
+	url: documentId ?? "",
+	headers: {
+		[DriverHeader.createNew]: true,
+	},
+});

--- a/src/Nostrcollab/index.ts
+++ b/src/Nostrcollab/index.ts
@@ -1,3 +1,3 @@
 export { NostrContainerRuntimeFactory } from "./container";
 export { NostrCollabLoader, StaticCodeLoader } from "./loader";
-export { NostrRelayUrlResolver, createNostrCreateNewRequest } from "./driver";
+export { NostrRelayUrlResolver, NostrRelayTokenProvider, createNostrCreateNewRequest } from "./driver";

--- a/src/Nostrcollab/index.ts
+++ b/src/Nostrcollab/index.ts
@@ -1,2 +1,3 @@
 export { NostrContainerRuntimeFactory } from "./container";
 export { NostrCollabLoader, StaticCodeLoader } from "./loader";
+export { NostrRelayUrlResolver, createNostrCreateNewRequest } from "./driver";

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,11 @@
-import {
-	createTinyliciousCreateNewRequest,
-	InsecureTinyliciousTokenProvider,
-	InsecureTinyliciousUrlResolver,
-} from "@fluidframework/tinylicious-driver";
+import { InsecureTinyliciousTokenProvider } from "@fluidframework/tinylicious-driver";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
-import { StaticCodeLoader, NostrCollabLoader } from "./Nostrcollab";
+import {
+	StaticCodeLoader,
+	NostrCollabLoader,
+	createNostrCreateNewRequest,
+	NostrRelayUrlResolver,
+} from "./Nostrcollab";
 import {
 	renderHighlightCollection,
 	IHighlightCollectionAppModel,
@@ -16,10 +17,10 @@ const loadCollabHighlighter = async (pane: HTMLElement, author: string) => {
 
 	// Create a new Fluid loader, load the highlight collection
 	const loader = new NostrCollabLoader<IHighlightCollectionAppModel>({
-		urlResolver: new InsecureTinyliciousUrlResolver(),
+		urlResolver: new NostrRelayUrlResolver(),
 		documentServiceFactory: new RouterliciousDocumentServiceFactory(tokenProvider),
 		codeLoader: new StaticCodeLoader(new HighlightContainerRuntimeFactory()),
-		generateCreateNewRequest: createTinyliciousCreateNewRequest,
+		generateCreateNewRequest: createNostrCreateNewRequest,
 	});
 
 	let id: string;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,10 @@
-import { InsecureTinyliciousTokenProvider } from "@fluidframework/tinylicious-driver";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 import {
 	StaticCodeLoader,
 	NostrCollabLoader,
 	createNostrCreateNewRequest,
 	NostrRelayUrlResolver,
+	NostrRelayTokenProvider,
 } from "./Nostrcollab";
 import {
 	renderHighlightCollection,
@@ -13,7 +13,7 @@ import {
 } from "./Highlight";
 
 const loadCollabHighlighter = async (pane: HTMLElement, author: string) => {
-	const tokenProvider = new InsecureTinyliciousTokenProvider();
+	const tokenProvider = new NostrRelayTokenProvider();
 
 	// Create a new Fluid loader, load the highlight collection
 	const loader = new NostrCollabLoader<IHighlightCollectionAppModel>({


### PR DESCRIPTION
Fork fluid framework specific components that we need to modify and rebuild on Nostr protocol architecture.
This PR sketches the following components to make up the Nostr-FF integration

- `NostrRelayUrlResolver` is used by the collab container object to resolve collab endpoints on a relay specified by the client
- `NostrRelayTokenProvider` is injected by the client to the collab container object for purposes of **authentication and building of a user profice**
- `createNostrCreateNewRequest` a utility to construct requests for starting new collab sessions. **Create new**
 is a concept from FF, defined as the process of instantiating new collab objects (collab container objects and it's experiences)
 
 This PR just defines the pieces. On the next pass, we'll be making the actual adaptations on the components listed
