### PR TITLE
Nostr collab auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@fluidframework/routerlicious-driver": "^1.3.6",
 				"css-loader": "^6.0.0",
 				"fluid-framework": "^1.3.0",
+				"nostr-tools": "^1.7.4",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0",
 				"style-loader": "^3.0.0",
@@ -1672,6 +1673,86 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true
+		},
+		"node_modules/@noble/hashes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+			"integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+		},
+		"node_modules/@noble/secp256k1": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+			"integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			]
+		},
+		"node_modules/@scure/base": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+			"integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			]
+		},
+		"node_modules/@scure/bip32": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+			"integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"dependencies": {
+				"@noble/hashes": "~1.2.0",
+				"@noble/secp256k1": "~1.7.0",
+				"@scure/base": "~1.1.0"
+			}
+		},
+		"node_modules/@scure/bip32/node_modules/@noble/hashes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+			"integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			]
+		},
+		"node_modules/@scure/bip39": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+			"integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"dependencies": {
+				"@noble/hashes": "~1.2.0",
+				"@scure/base": "~1.1.0"
+			}
+		},
+		"node_modules/@scure/bip39/node_modules/@noble/hashes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+			"integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			]
 		},
 		"node_modules/@sideway/address": {
 			"version": "4.1.4",
@@ -6742,6 +6823,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/nostr-tools": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-1.7.4.tgz",
+			"integrity": "sha512-YowDJ+S3UW9KCYPDZfZXXMITrJSMjiCmFOK5HohyKkg+w6EipFUTkFRBPRA2BTLXO/qw8gukKXfL0B7Dv3jtcQ==",
+			"dependencies": {
+				"@noble/hashes": "1.0.0",
+				"@noble/secp256k1": "^1.7.1",
+				"@scure/base": "^1.1.1",
+				"@scure/bip32": "^1.1.5",
+				"@scure/bip39": "^1.1.1",
+				"prettier": "^2.8.4"
+			}
+		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -7214,7 +7308,6 @@
 			"version": "2.8.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
 			"integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0",
 		"style-loader": "^3.0.0",
-		"styled-components": "^5.3.9",
-		"uuid": "^9.0.0"
+		"styled-components": "^5.3.9"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@fluidframework/routerlicious-driver": "^1.3.6",
 		"css-loader": "^6.0.0",
 		"fluid-framework": "^1.3.0",
+		"nostr-tools": "^1.7.4",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0",
 		"style-loader": "^3.0.0",

--- a/src/Highlight/Components/App.tsx
+++ b/src/Highlight/Components/App.tsx
@@ -6,8 +6,9 @@ import {
   createNostrCreateNewRequest,
   NostrRelayUrlResolver,
   NostrRelayTokenProvider,
+  MockCollabRelay,
 } from "../../Nostrcollab";
-import { MockCollabRelay, NostrUser } from "../../Nostr";
+import { NostrUser } from "../../Nostr";
 import {
   renderHighlightCollection,
   IHighlightCollectionAppModel,

--- a/src/Highlight/Components/App.tsx
+++ b/src/Highlight/Components/App.tsx
@@ -7,23 +7,26 @@ import {
   NostrRelayUrlResolver,
   NostrRelayTokenProvider,
 } from "../../Nostrcollab";
-import { MockCollabRelay } from "../../Nostr";
+import { MockCollabRelay, NostrUser } from "../../Nostr";
 import {
   renderHighlightCollection,
   IHighlightCollectionAppModel,
   HighlightContainerRuntimeFactory,
 } from "../index";
 
-interface Props {
-  author: string;
+
+const collabRelay = new MockCollabRelay("wss://mockcollabrelay", 1);
+const mockNostrUser: NostrUser = {
+  pubkey: "0x1234",
+  meta: {}
 }
 
-function App({ author }: Props) {
-  const collabRelay = new MockCollabRelay("wss://mockcollabrelay", 1);
+function App() {
+  const [user] = React.useState<NostrUser>(mockNostrUser)
 
   useEffect(() => {
     const loadCollabHighlighter = async (pane: HTMLElement) => {
-      const tokenProvider = new NostrRelayTokenProvider(collabRelay );
+      const tokenProvider = new NostrRelayTokenProvider(collabRelay, user );
 
       // Create a new Fluid loader, load the highlight collection
       const loader = new NostrCollabLoader<IHighlightCollectionAppModel>({
@@ -49,7 +52,7 @@ function App({ author }: Props) {
       window.location.hash = id;
       document.title = id;
 
-      renderHighlightCollection(highlightsCollection.highlightCollection, pane, author);
+      renderHighlightCollection(highlightsCollection.highlightCollection, pane, user.pubkey);
     };
 
     // Load Collab highlighter on the LEFT pane
@@ -59,7 +62,7 @@ function App({ author }: Props) {
     // Load Collab highlighter on the RIGHT pane
     const right = document.getElementById("right-hltr");
     right && loadCollabHighlighter(right);
-  }, [author]);
+  }, [user]);
 
   return (
     <div>

--- a/src/Highlight/Components/App.tsx
+++ b/src/Highlight/Components/App.tsx
@@ -7,6 +7,7 @@ import {
   NostrRelayUrlResolver,
   NostrRelayTokenProvider,
 } from "../../Nostrcollab";
+import { MockCollabRelay } from "../../Nostr";
 import {
   renderHighlightCollection,
   IHighlightCollectionAppModel,
@@ -18,9 +19,11 @@ interface Props {
 }
 
 function App({ author }: Props) {
+  const collabRelay = new MockCollabRelay("wss://mockcollabrelay", 1);
+
   useEffect(() => {
     const loadCollabHighlighter = async (pane: HTMLElement) => {
-      const tokenProvider = new NostrRelayTokenProvider();
+      const tokenProvider = new NostrRelayTokenProvider(collabRelay );
 
       // Create a new Fluid loader, load the highlight collection
       const loader = new NostrCollabLoader<IHighlightCollectionAppModel>({

--- a/src/Nostr.ts
+++ b/src/Nostr.ts
@@ -1,0 +1,45 @@
+import { Event, Filter, Pub, Sub, SubscriptionOptions } from 'nostr-tools';
+
+export class MockCollabRelay {
+  constructor(public readonly url: string, public status: number) { }
+
+  public connect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public close(): void {
+    return;
+  }
+
+  public sub(_filters: Filter[], _opts?: SubscriptionOptions): Sub {
+    return {
+      sub: (filters: Filter[], opts: SubscriptionOptions) => this.sub(filters, opts),
+      unsub: () => { },
+      on: (_type: 'event' | 'eose', _cb: any) => { },
+      off: (_type: 'event' | 'eose', _cb: any) => { },
+    };
+  };
+
+  public list(_filters: Filter[], _opts?: SubscriptionOptions | undefined): Promise<Event[]> {
+    return Promise.resolve([]);
+  };
+
+  public get(_filter: Filter, _opts?: SubscriptionOptions | undefined): Promise<Event | null> {
+    return Promise.resolve(null);
+  }
+
+  public publish(_event: Event): Pub {
+    return {
+      on: (_type: 'ok' | 'failed', _cb: any) => { },
+      off: (_type: 'ok' | 'failed', _cb: any) => { },
+    };
+  }
+
+  public on(_type: 'connect' | 'disconnect' | 'error' | 'notice', _cb: any): void {
+    return;
+  }
+
+  public off(_type: 'connect' | 'disconnect' | 'error' | 'notice', _cb: any): void {
+    return;
+  }
+}

--- a/src/Nostr.ts
+++ b/src/Nostr.ts
@@ -1,54 +1,8 @@
-import { Event, Filter, Pub, Sub, SubscriptionOptions } from 'nostr-tools';
-
-export class MockCollabRelay {
-  constructor(public readonly url: string, public status: number) { }
-
-  public connect(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  public close(): void {
-    return;
-  }
-
-  public sub(_filters: Filter[], _opts?: SubscriptionOptions): Sub {
-    return {
-      sub: (filters: Filter[], opts: SubscriptionOptions) => this.sub(filters, opts),
-      unsub: () => { },
-      on: (_type: 'event' | 'eose', _cb: any) => { },
-      off: (_type: 'event' | 'eose', _cb: any) => { },
-    };
-  };
-
-  public list(_filters: Filter[], _opts?: SubscriptionOptions | undefined): Promise<Event[]> {
-    return Promise.resolve([]);
-  };
-
-  public get(_filter: Filter, _opts?: SubscriptionOptions | undefined): Promise<Event | null> {
-    return Promise.resolve(null);
-  }
-
-  public publish(_event: Event): Pub {
-    return {
-      on: (_type: 'ok' | 'failed', _cb: any) => { },
-      off: (_type: 'ok' | 'failed', _cb: any) => { },
-    };
-  }
-
-  public on(_type: 'connect' | 'disconnect' | 'error' | 'notice', _cb: any): void {
-    return;
-  }
-
-  public off(_type: 'connect' | 'disconnect' | 'error' | 'notice', _cb: any): void {
-    return;
-  }
-}
-
 export interface NostrUser {
-  pubkey: string;
-  meta: NostrUserMetadata;
+	pubkey: string;
+	meta: NostrUserMetadata;
 }
 
 export interface NostrUserMetadata {
-  [pubkey: string]: string;
+	[pubkey: string]: string;
 }

--- a/src/Nostr.ts
+++ b/src/Nostr.ts
@@ -43,3 +43,12 @@ export class MockCollabRelay {
     return;
   }
 }
+
+export interface NostrUser {
+  pubkey: string;
+  meta: NostrUserMetadata;
+}
+
+export interface NostrUserMetadata {
+  [pubkey: string]: string;
+}

--- a/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
+++ b/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
@@ -57,10 +57,11 @@ export class NostrRelayTokenProvider implements ITokenProvider {
 	): Promise<NostrCollabToken> {
 		const tenantFilter = tenantId ? [tenantId] : [];
 		const docFilter = documentId ? [documentId] : [];
+
 		let event = await this.collabRelay.get({
 			"kinds": [KIND_COLLAB_TOKEN],
 			"#tenant": tenantFilter,
-			"#doc": docFilter,
+			"#document": docFilter,
 		});
 
 		if (event) {
@@ -82,7 +83,6 @@ export class NostrRelayTokenProvider implements ITokenProvider {
 export interface NostrCollabToken {
 	tenantId: string;
 	documentId: string;
-	token: string;
 	scopes: ScopeType[];
 	iat: number;
 	exp: number;

--- a/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
+++ b/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
@@ -12,7 +12,7 @@ export class NostrRelayTokenProvider implements ITokenProvider {
 		private readonly collabRelay: Relay,
 		// The host should provide a user identity. Possibbly sourced from other relays?
 		private readonly nostrUser: NostrUser,
-	) { }
+	) {}
 
 	public async fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
 		return {

--- a/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
+++ b/src/Nostrcollab/driver/NostrRelayTokenProvider.ts
@@ -2,6 +2,7 @@ import { ScopeType, ITokenClaims } from "@fluidframework/protocol-definitions";
 import { ITokenProvider, ITokenResponse } from "@fluidframework/routerlicious-driver";
 import { KJUR as jsrsasign } from "jsrsasign";
 import { Relay } from "nostr-tools";
+import { NostrUser } from "../../Nostr";
 import { KIND_COLLAB_TOKEN } from "./constants";
 
 /** Produces authentication tokens for accessing collab docs served by a relay */
@@ -10,8 +11,8 @@ export class NostrRelayTokenProvider implements ITokenProvider {
 		// The host should provide a pre-connected Nostr collab relay
 		private readonly collabRelay: Relay,
 		// The host should provide a user identity. Possibbly sourced from other relays?
-		private readonly nostrUser: { pubkey: string; name: string },
-	) {}
+		private readonly nostrUser: NostrUser,
+	) { }
 
 	public async fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse> {
 		return {
@@ -33,7 +34,7 @@ export class NostrRelayTokenProvider implements ITokenProvider {
 		ver: string = "1.0",
 	): Promise<string> {
 		const collab = await this.fetchNostrCollabToken(tenantId, documentId);
-		const user = { id: this.nostrUser.pubkey, name: this.nostrUser.name };
+		const user = { id: this.nostrUser.pubkey, name: this.nostrUser.meta["name"] || "" };
 
 		const claims: ITokenClaims = {
 			...collab,

--- a/src/Nostrcollab/driver/constants.ts
+++ b/src/Nostrcollab/driver/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * PROPOSED:
+ *
+ * Nostr event kind for authenticated Nostr Collab Relays to send auth tokens and claims to clients
+ * that want to collab on shared objects (documents) hosted by the relay.
+ */
+export const KIND_COLLAB_TOKEN = 4201;

--- a/src/Nostrcollab/driver/index.ts
+++ b/src/Nostrcollab/driver/index.ts
@@ -1,3 +1,4 @@
 export * from "./NostrRelayUrlResolver";
 export * from "./NostrRelayTokenProvider";
 export * from "./utils";
+export * from "./constants";

--- a/src/Nostrcollab/index.ts
+++ b/src/Nostrcollab/index.ts
@@ -5,3 +5,4 @@ export {
 	NostrRelayTokenProvider,
 	createNostrCreateNewRequest,
 } from "./driver";
+export { MockCollabRelay } from "./relay";

--- a/src/Nostrcollab/index.ts
+++ b/src/Nostrcollab/index.ts
@@ -1,3 +1,7 @@
 export { NostrContainerRuntimeFactory } from "./container";
 export { NostrCollabLoader, StaticCodeLoader } from "./loader";
-export { NostrRelayUrlResolver, NostrRelayTokenProvider, createNostrCreateNewRequest } from "./driver";
+export {
+	NostrRelayUrlResolver,
+	NostrRelayTokenProvider,
+	createNostrCreateNewRequest,
+} from "./driver";

--- a/src/Nostrcollab/relay.ts
+++ b/src/Nostrcollab/relay.ts
@@ -1,0 +1,45 @@
+import { Event, Filter, Pub, Sub, SubscriptionOptions } from "nostr-tools";
+
+export class MockCollabRelay {
+	constructor(public readonly url: string, public status: number) {}
+
+	public connect(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	public close(): void {
+		return;
+	}
+
+	public sub(_filters: Filter[], _opts?: SubscriptionOptions): Sub {
+		return {
+			sub: (filters: Filter[], opts: SubscriptionOptions) => this.sub(filters, opts),
+			unsub: () => {},
+			on: (_type: "event" | "eose", _cb: any) => {},
+			off: (_type: "event" | "eose", _cb: any) => {},
+		};
+	}
+
+	public list(_filters: Filter[], _opts?: SubscriptionOptions | undefined): Promise<Event[]> {
+		return Promise.resolve([]);
+	}
+
+	public get(_filter: Filter, _opts?: SubscriptionOptions | undefined): Promise<Event | null> {
+		return Promise.resolve(null);
+	}
+
+	public publish(_event: Event): Pub {
+		return {
+			on: (_type: "ok" | "failed", _cb: any) => {},
+			off: (_type: "ok" | "failed", _cb: any) => {},
+		};
+	}
+
+	public on(_type: "connect" | "disconnect" | "error" | "notice", _cb: any): void {
+		return;
+	}
+
+	public off(_type: "connect" | "disconnect" | "error" | "notice", _cb: any): void {
+		return;
+	}
+}

--- a/src/Nostrcollab/relay.ts
+++ b/src/Nostrcollab/relay.ts
@@ -1,4 +1,6 @@
+import { ScopeType } from "@fluidframework/protocol-definitions";
 import { Event, Filter, Pub, Sub, SubscriptionOptions } from "nostr-tools";
+import { NostrCollabToken, KIND_COLLAB_TOKEN } from "./driver";
 
 export class MockCollabRelay {
 	constructor(public readonly url: string, public status: number) {}
@@ -20,11 +22,33 @@ export class MockCollabRelay {
 		};
 	}
 
-	public list(_filters: Filter[], _opts?: SubscriptionOptions | undefined): Promise<Event[]> {
+	public list(filters: Filter[], _opts?: SubscriptionOptions | undefined): Promise<Event[]> {
 		return Promise.resolve([]);
 	}
 
-	public get(_filter: Filter, _opts?: SubscriptionOptions | undefined): Promise<Event | null> {
+	public get(filter: Filter, _opts?: SubscriptionOptions | undefined): Promise<Event | null> {
+		if (filter.kinds?.includes(KIND_COLLAB_TOKEN)) {
+			const tenant = filter["#tenant"]?.[0];
+			const document = filter["#document"]?.[0] || "";
+
+			if (!tenant) {
+				return Promise.resolve(null);
+			}
+
+			const token = generateCollabToken(tenant, document);
+
+			// TODO: Switch to NIP-42 AUTH event kind
+			// https://github.com/nostr-protocol/nips/blob/be0a426745252eeb420a38e4896b28059b4f7fa5/42.md
+			return Promise.resolve({
+				id: "idid",
+				pubkey: "pubkey",
+				kind: KIND_COLLAB_TOKEN,
+				content: JSON.stringify(token),
+				created_at: Math.round(new Date().getTime() / 1000),
+				tags: [],
+				sig: "sig",
+			});
+		}
 		return Promise.resolve(null);
 	}
 
@@ -43,3 +67,15 @@ export class MockCollabRelay {
 		return;
 	}
 }
+
+const generateCollabToken = (tenantId: string, documentId: string): NostrCollabToken => {
+	const now = Math.round(new Date().getTime() / 1000);
+
+	return {
+		tenantId,
+		documentId,
+		scopes: [ScopeType.DocRead, ScopeType.DocWrite, ScopeType.SummaryWrite],
+		iat: now,
+		exp: now + 60 * 60,
+	};
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,4 +4,4 @@ import App from "./Highlight/Components/App";
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 
-root.render(<App  author="John Doe"/>);
+root.render(<App/>);


### PR DESCRIPTION
A sketch of how pubkeys get collab authentication over objects hosted by a Nostr collab relay. The following primitives are needed by the fluid framework auth model, and can be adopted in Nostr collab definitions as well
- **User**: as identified by some id (pubkey) and optional metadata (i.e. name)
  - nostr users are identified by **pubkeys**
  - users need scoped tokens to interact with collab documents

- **Tenant**: as identified by **tenantId**
  - a grouping of users and resources, plainly defined as a list / group / organization.
  - collab documents are resources parented under a tenant
  -  users live within tenants (even if it's their own tenant?)

- **Document**: as identified by **documentId**
  - an identifier for a Fluid collab document.
  - similarly, an identifier for Nostr collab document (object).
  - users own documents

- **Scope**:  as identified by `ScopeType`
  - permissions a user can have over each collab object (document)
  - are of three types [Read, Write, Summarize]
  - can be granted/retracted from one user to another i.e. a user can grant [Read] permission to other users
  - can be granted temporally. i.e scope grants have lifetimes (expiry where necessary)
 
> Relay that hosts collab experience should have capabilities of authenticating users or groups of users, therefore granting/limiting collab access to documents. Apply scopes for this purpose